### PR TITLE
gherkin syntax changes and steps rework

### DIFF
--- a/e2e/_suites/ingest-manager/features/ingest-manager.feature
+++ b/e2e/_suites/ingest-manager/features/ingest-manager.feature
@@ -1,12 +1,12 @@
 @ingest
-Feature: Enable Fleet and Deploy Agent basic end to end tests
+Feature: Enable Fleet and Deploy Agent
 
 @enroll
 Scenario: Deploying an agent
   Given the "Fleet" Kibana setup has been executed
     And an agent is deployed to Fleet
-  Then the agent is listed in Fleet as online
-    And system package dashboards are listed in Fleet
+  When the agent is listed in Fleet as online
+    Then system package dashboards are listed in Fleet
     And new documents are inserted into Elasticsearch
 
 @start-agent
@@ -32,7 +32,8 @@ Scenario: Un-enrolling an agent
 @reenroll
 Scenario: Re-enrolling an agent
   Given an agent is enrolled
-    And the agent is un-enrolled and stopped on the host
+    And the agent is un-enrolled
+    And the Agent is stopped on the host
   When the agent is re-enrolled on the host
     And the agent is run on the host
   Then the agent is listed in Fleet as online
@@ -42,6 +43,6 @@ Scenario: Re-enrolling an agent
 Scenario: Revoking the enrollment token for an agent
   Given an agent is enrolled
   When the enrollment token is revoked
-    Then new documents are inserted into Elasticsearch
+    And new documents are inserted into Elasticsearch
   And the agent is un-enrolled and stopped on the host
   Then the agent cannot be re-enrolled with the same command


### PR DESCRIPTION
Hi - here are the specific changes I was thinking of.  They should allow more re-use of the feature level commands, but I know we can always copy / paste some amount of code and abstract items on the implementation files.

For instance, it makes sense to me to have the explicit host-side steps broken down to:
 - enroll agent
 - start agent
 - stop agent
 
Those can be the building blocks for all the actions done on the host side, and those in combination with the the Kibana API calls should represent what customer usage will be.